### PR TITLE
Prevent large images from overflowing off the side of the page for avenir-white.css

### DIFF
--- a/avenir-white.css
+++ b/avenir-white.css
@@ -1,16 +1,3 @@
-table {
-	border-collapse: collapse;
-	width: 100%;
-}
-
-table, th, td {
-  border: 1px solid #EAEAEA;
-	
-	border-radius: 3px;
-  padding: 5px;
-}
-
-tr:nth-child(even) {background-color: #F8F8F8}
 
 body {
 	font-family: "Avenir Next", Helvetica, Arial, sans-serif;
@@ -62,6 +49,26 @@ hr {
 
 p, blockquote, ul, ol, dl, li, table, pre {
 	margin: 15px 0;
+}
+
+img {
+	max-width: 100%;
+}
+
+table {
+	border-collapse: collapse;
+	width: 100%;
+}
+
+table, th, td {
+	border: 1px solid #EAEAEA;
+	
+	border-radius: 3px;
+	padding: 5px;
+}
+
+tr:nth-child(even) {
+  background-color: #F8F8F8;
 }
 
 a, a:visited {


### PR DESCRIPTION
## Before:

![avenir-old](https://user-images.githubusercontent.com/5248352/30046145-4aba9a0a-91bd-11e7-8519-211732b4a375.png)

## After:

![avenir-new](https://user-images.githubusercontent.com/5248352/30046152-55b94dca-91bd-11e7-9d59-980facc2b718.png)
