### PR TITLE
set max-width for img tags to 100% for foghorn.css

### DIFF
--- a/foghorn.css
+++ b/foghorn.css
@@ -1,5 +1,9 @@
 @import url(http://fonts.googleapis.com/css?family=Vollkorn:400,400italic,700,700italic&subset=latin);
 
+img {
+	max-width: 100%;
+}
+
 table {
 	width: 100%;
 }


### PR DESCRIPTION
Solves the same problem as https://github.com/jasonm23/markdown-css-themes/commit/14851e57e0d592a5f9b0b1c11b3a8c092bad0b83, but for foghorn.css